### PR TITLE
Add Apache Commons Text javadoc link

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <div class="jdbox"><div><a href="Bio-Formats/"><img src="icons/bio-formats-icon-64.png" border="0" /></div>Bio-Formats</a></div>
   <div class="jdbox"><div><a href="Apache-Commons-Lang/"><img src="icons/apache-icon-64.png" border="0" /></div>Commons Lang</a></div>
   <div class="jdbox"><div><a href="Apache-Commons-Math/"><img src="icons/apache-icon-64.png" border="0" /></div>Commons Math</a></div>
+  <div class="jdbox"><div><a href="Apache-Commons-Text/"><img src="icons/apache-icon-64.png" border="0" /></div>Commons Text</a></div>
   <div class="jdbox"><div><a href="Eclipse/overview-summary.html"><img src="icons/eclipse-icon-64.png" border="0" /></div>Eclipse</a></div>
   <div class="jdbox"><div><a href="Fiji/"><img src="icons/fiji-icon-64.png" border="0" /></div>Fiji</a></div>
   <div class="jdbox"><div><a href="Guava/"><img src="icons/java-icon-64.png" border="0" /></div>Google Guava</a></div>


### PR DESCRIPTION
This will require creation of a redirect for http://javadoc.scijava.org/Apache-Commons-Text/
