### PR TITLE
Remove link to ImageJ1, as it is no longer working

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
   <div class="jdbox"><div><a href="Guava/"><img src="icons/java-icon-64.png" border="0" /></div>Google Guava</a></div>
   <div class="jdbox"><div><a href="Icy/"><img src="icons/icy-icon-64.png" border="0" /></div>Icy</a></div>
   <div class="jdbox"><div><a href="ImageJ/"><img src="icons/imagej2-icon-64.png" border="0" /></div>ImageJ</a></div>
-  <div class="jdbox"><div><a href="ImageJ1/"><img src="icons/imagej1-icon-64.png" border="0" /></div>ImageJ1</a></div>
   <div class="jdbox"><div><a href="ImgLib2/"><img src="icons/imglib2-icon-64.png" border="0" /></div>ImgLib2</a></div>
   <div class="jdbox"><div><a href="JAMA/"><img src="icons/java-icon-64.png" border="0" /></div>JAMA</a></div>
   <div class="jdbox"><div><a href="Java3D/"><img src="icons/java3d-icon-64.png" border="0" /></div>Java 3D</a></div>


### PR DESCRIPTION
I've noticed that on the website the link to the ImageJ1 Javadocs is broken. I've removed it. 